### PR TITLE
Resolve the issue of repeated triggering of events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 markdown-it-code-copy-*.tgz
 .history
 node_modules
+*.iml

--- a/index.js
+++ b/index.js
@@ -1,56 +1,57 @@
 const merge = require('lodash.merge');
-
-let clipboard = null;
-try {
-	// Node js will throw an error
-	this === window;
-
-	const Clipboard = require('clipboard');
-	clipboard = new Clipboard('.markdown-it-code-copy');
-}
-catch (_err) {
-}
-
+const Clipboard = require("clipboard");
+const {v4: uuidv4} = require('uuid');
 const defaultOptions = {
-	iconStyle: 'font-size: 21px; opacity: 0.4;',
-	iconClass: 'mdi mdi-content-copy',
-	buttonStyle: 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;',
-	buttonClass: '',
-  element: ''
+    iconStyle: 'font-size: 21px; opacity: 0.4;',
+    iconClass: 'mdi mdi-content-copy',
+    buttonStyle: 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;',
+    buttonClass: '',
+    element: ''
 };
 
-function renderCode(origRule, options) {
-	options = merge(defaultOptions, options);
-	return (...args) => {
-		const [tokens, idx] = args;
-		const content = tokens[idx].content
-			.replaceAll('"', '&quot;')
-			.replaceAll("'", "&apos;");
-		const origRendered = origRule(...args);
+function renderCode(origRule, options, id) {
+    options = merge(defaultOptions, options);
+    return (...args) => {
+        const [tokens, idx] = args;
+        const content = tokens[idx].content
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", "&apos;");
+        const origRendered = origRule(...args);
 
-		if (content.length === 0)
-			return origRendered;
+        if (content.length === 0)
+            return origRendered;
 
-		return `
+        return `
 <div style="position: relative">
 	${origRendered}
-	<button class="markdown-it-code-copy ${options.buttonClass}" data-clipboard-text="${content}" style="${options.buttonStyle}" title="Copy">
+	<button class="markdown-it-code-copy binding-${id} ${options.buttonClass}" data-clipboard-text="${content}" style="${options.buttonStyle}" title="Copy">
 		<span style="${options.iconStyle}" class="${options.iconClass}">${options.element}</span>
 	</button>
 </div>
 `;
-	};
+    };
 }
 
 module.exports = (md, options) => {
-	if (clipboard) {
-		if (options.onSuccess) {
-			clipboard.on("success", options.onSuccess);
-		}
-		if (options.onError) {
-			clipboard.on("error", options.onError);
-		}
-	}
-	md.renderer.rules.code_block = renderCode(md.renderer.rules.code_block, options);
-	md.renderer.rules.fence = renderCode(md.renderer.rules.fence, options);
+    let clipboard = null;
+    let id = uuidv4();
+    try {
+        // Node js will throw an error
+        this === window;
+
+        const Clipboard = require('clipboard');
+        clipboard = new Clipboard('.markdown-it-code-copy.binding-' + id);
+    } catch (_err) {
+    }
+    if (clipboard) {
+        if (options.onSuccess) {
+            clipboard.on("success", options.onSuccess);
+        }
+        if (options.onError) {
+            clipboard.on("error", options.onError);
+        }
+    }
+
+    md.renderer.rules.code_block = renderCode(md.renderer.rules.code_block, options, id);
+    md.renderer.rules.fence = renderCode(md.renderer.rules.fence, options, id);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.6",
-        "lodash.merge": "^4.6.2"
+        "lodash.merge": "^4.6.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "markdown-it": "^12.3.2"
@@ -105,6 +106,19 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://dev.joysfintech.com/joys-nexus/repository/npm-public/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "clipboard": "^2.0.6",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "markdown-it": "^12.3.2"


### PR DESCRIPTION
When markdown-it-code-copy is applied to multiple components on the same page, clicking the copy button on any code block will repeatedly trigger success or error events. This PR avoids this issue by adding a unique identifier. Please review.