### PR TITLE
Remove newline at the end of copied content

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const md = require('markdown-it')()
 | buttonStyle      | 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;' | The style of the button wrapper            |
 | buttonClass      | ''                                                                            | The class of the button wrapper            |
 | element          | ''                                                                            | Custom HTML element as button body         |
-| removeEndNewline | false                                                                         | Remove newline at the end if copied string |
+| removeEndNewline | false                                                                         | Remove newline at the end of copied string |
 | onSuccess        | undefined                                                                     | Function to call when copied successfully  |
 | onError          | undefined                                                                     | Function to call when error occurred       |
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ const md = require('markdown-it')()
 
 ### Options
 
-| Name        | Default                                                                       | Description                               |
-|-------------|-------------------------------------------------------------------------------|-------------------------------------------|
-| iconStyle   | 'font-size: 21px; opacity: 0.4;'                                              | The style of copy icon                    |
-| iconClass   | 'mdi mdi-content-copy'                                                        | The class of copy icon                    |
-| buttonStyle | 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;' | The style of the button wrapper           |
-| buttonClass | ''                                                                            | The class of the button wrapper           |
-| element     | ''                                                                            | Custom HTML element as button body        |
-| onSuccess   | undefined                                                                     | Function to call when copied successfully |
-| onError     | undefined                                                                     | Function to call when error occurred      |
+| Name             | Default                                                                       | Description                                |
+|------------------|-------------------------------------------------------------------------------|--------------------------------------------|
+| iconStyle        | 'font-size: 21px; opacity: 0.4;'                                              | The style of copy icon                     |
+| iconClass        | 'mdi mdi-content-copy'                                                        | The class of copy icon                     |
+| buttonStyle      | 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;' | The style of the button wrapper            |
+| buttonClass      | ''                                                                            | The class of the button wrapper            |
+| element          | ''                                                                            | Custom HTML element as button body         |
+| removeEndNewline | false                                                                         | Remove newline at the end if copied string |
+| onSuccess        | undefined                                                                     | Function to call when copied successfully  |
+| onError          | undefined                                                                     | Function to call when error occurred       |
 
 **Tips**:
 If you want to use a different icon font,

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function renderCode(origRule, options) {
 			.replaceAll('"', '&quot;')
 			.replaceAll("'", "&apos;");
 
-		if (options.removeEndNewline) {
-			content.replace(/(\r\n|\n|\r)+$/, '');
+		if (options.removeEndNewline === true) {
+			content = content.replace(/(\r\n|\n|\r)+$/, '');
 		}
 
 		const origRendered = origRule(...args);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ function renderCode(origRule, options) {
 		const [tokens, idx] = args;
 		const content = tokens[idx].content
 			.replaceAll('"', '&quot;')
-			.replaceAll("'", "&apos;");
+			.replaceAll("'", "&apos;")
+			.replace(/(\r\n|\n|\r)+$/, '');
 		const origRendered = origRule(...args);
 
 		if (content.length === 0)

--- a/index.js
+++ b/index.js
@@ -16,17 +16,22 @@ const defaultOptions = {
 	iconClass: 'mdi mdi-content-copy',
 	buttonStyle: 'position: absolute; top: 7.5px; right: 6px; cursor: pointer; outline: none;',
 	buttonClass: '',
-  element: ''
+	element: '',
+	removeEndNewline: false
 };
 
 function renderCode(origRule, options) {
 	options = merge(defaultOptions, options);
 	return (...args) => {
 		const [tokens, idx] = args;
-		const content = tokens[idx].content
+		let content = tokens[idx].content
 			.replaceAll('"', '&quot;')
-			.replaceAll("'", "&apos;")
-			.replace(/(\r\n|\n|\r)+$/, '');
+			.replaceAll("'", "&apos;");
+
+		if (options.removeEndNewline) {
+			content.replace(/(\r\n|\n|\r)+$/, '');
+		}
+
 		const origRendered = origRule(...args);
 
 		if (content.length === 0)


### PR DESCRIPTION
It is just a little change, but removing newline at the end of every copied content was annoying.
For example passwords or bash commands with newline at the end suffer from this the most.

This change simply removes any newline at the end of the copied string.